### PR TITLE
Adblock agent support, modifier separator fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.0.27
+
+- Added support for adblock agents
+- Fix redundant modifier detection: #25
+
 ## 0.0.26
 
 - Added support for cosmetic rules modifiers: #47

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "adblock",
     "displayName": "Adblock/AdGuard/uBlock filters grammar",
     "description": "VS code extension that adds support for ad blocking rules syntax.",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "publisher": "adguard",
     "icon": "images/icon.png",
     "engines": {

--- a/syntaxes/adblock.tmLanguage.json
+++ b/syntaxes/adblock.tmLanguage.json
@@ -2,6 +2,9 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Adblock",
 	"patterns": [
+        {
+			"include": "#adblockAgent"
+		},
 		{
 			"include": "#preprocessor"
 		},
@@ -37,6 +40,51 @@
 		}
 	],
 	"repository": {
+        "adblockAgent": {
+			"patterns": [
+				{
+					"match": "^(\\[)([^\\]]+)(\\])\\s*$",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.array.start.ablock.agent"
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#adblockData"
+								},
+								{
+									"match": ";",
+									"name": "punctuation.separator"
+								},
+								{
+									"name": "invalid.illegal",
+									"match": ".*"
+								}
+							]
+						},
+						"3": {
+							"name": "punctuation.definition.array.end.ablock.agent"
+						}
+					}
+				}
+			]
+		},
+		"adblockData": {
+			"patterns": [
+				{
+					"match": "(?:\\s*)([Aa]d[Bb]lock(?:\\s[Pp]lus)?|u[Bb]lock(?:\\s[Oo]rigin)?|[Aa]d[Gg]uard)(?:\\s+(\\d+(?:\\.\\d+)*+\\+?))?(?:\\s*)",
+					"captures": {
+						"1": {
+							"name": "constant.language.agent.adblocker.name"
+						},
+						"2": {
+							"name": "constant.numeric.decimal"
+						}
+					}
+				}
+			]
+		},
 		"preprocessor": {
 			"patterns": [
 				{
@@ -141,10 +189,6 @@
 				{
 					"name": "comment.line",
 					"match": "^!.*"
-				},
-				{
-					"name": "comment.line.header",
-					"match": "^\\[Adblock.*"
 				},
 				{
 					"name": "comment.line.batch-style",

--- a/syntaxes/adblock.tmLanguage.json
+++ b/syntaxes/adblock.tmLanguage.json
@@ -449,7 +449,7 @@
 		"basicRules": {
 			"patterns": [
 				{
-					"match": "^(.+?)((\\$)(.*))?$",
+					"match": "^(.+?)((\\$(?!\\/))(.*))?$",
 					"captures": {
 						"1": {
 							"patterns": [
@@ -702,6 +702,10 @@
 				{
 					"match": ",",
 					"name": "punctuation.definition.adblock"
+				},
+				{
+					"match": "\\$",
+					"name": "invalid.illegal.redundant.modifier.separator"
 				}
 			]
 		},

--- a/test_rules.txt
+++ b/test_rules.txt
@@ -1,3 +1,5 @@
+[Adblock Plus 3.1; AdGuard]
+[AdGuard; Invalid Name 2.0]
 !
 ! Test rules for the syntax highlighter
 !

--- a/test_rules.txt
+++ b/test_rules.txt
@@ -311,3 +311,9 @@ $removeheader=location,domain=zannn.top|innal.top
 ! Cosmetic rules modifiers, invalid modifiers
 !
 [$randommodifier=test]##banner
+
+! https://github.com/ameshkov/VscodeAdblockSyntax/issues/25
+/^https:\/\/.*?\/v2\/0\/[a-zA-Z0-9_-]{30,}$/$third-party,script,$domain=~example.org
+||example.com/example.js^$script,$third-party,$domain=example.org
+||example.com/example.js^$script,$~third-party,$domain=example.org
+||example.com/example.js^$script,third-party,$domain=example.org|example.net


### PR DESCRIPTION
- Adblock Agent support: `[AdGuard]`, `[uBlock Origin]`, etc.
- Fix https://github.com/ameshkov/VscodeAdblockSyntax/issues/25

[Click here for live preview](https://novalightshow.netlify.app/?grammar-type=url&grammar=https%3A%2F%2Fraw.githubusercontent.com%2Fscripthunter7%2FVscodeAdblockSyntax%2Fmaster%2Fsyntaxes%2Fadblock.tmLanguage.json&sample-type=url&sample=https%3A%2F%2Fraw.githubusercontent.com%2Fscripthunter7%2FVscodeAdblockSyntax%2Fmaster%2Ftest_rules.txt)