### PR TITLE
JS/CSS highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
             {
                 "language": "adblock",
                 "scopeName": "text.adblock",
-                "path": "./syntaxes/adblock.tmLanguage.json"
+                "path": "./syntaxes/adblock.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.js": "javascript"
+                }
             }
         ]
     }

--- a/syntaxes/adblock.tmLanguage.json
+++ b/syntaxes/adblock.tmLanguage.json
@@ -404,8 +404,8 @@
 		"jsRules": {
 			"patterns": [
 				{
-					"match": "^(.*?)(#@?%#)(.+)$",
-					"captures": {
+					"begin": "^(.*?)(#@?%#)",
+					"beginCaptures": {
 						"1": {
 							"patterns": [
 								{
@@ -415,15 +415,15 @@
 						},
 						"2": {
 							"name": "keyword.control.adblock"
-						},
-						"3": {
-							"patterns": [
-								{
-									"include": "#jsFunction"
-								}
-							]
 						}
-					}
+					},
+					"end": "$",
+					"contentName": "source.js",
+					"patterns": [
+						{
+							"include": "source.js"
+						}
+					]
 				}
 			]
 		},
@@ -849,14 +849,6 @@
 				{
 					"name": "invalid.illegal.adblock",
 					"match": ".*"
-				}
-			]
-		},
-		"jsFunction": {
-			"patterns": [
-				{
-					"name": "constant.character.jscode.adblock",
-					"match": ".+"
 				}
 			]
 		},


### PR DESCRIPTION
# JS embedding

<details>
<summary>Show screenshot</summary>

![image](https://user-images.githubusercontent.com/57285466/184623572-979e8d9e-972e-4426-8da4-ab35e3b952a0.png)

</details>

JS embedding is also possible in Linguist: https://github.com/github/linguist/discussions/6020#discussioncomment-3397226

# CSS highlight (in progress)

My own CSS highlight that also supports AdGuard's [ExtendedCss](https://github.com/AdguardTeam/ExtendedCss)

<details>
<summary>Show screenshot</summary>

![image](https://user-images.githubusercontent.com/57285466/184624040-254aaa77-dc6b-4848-a86e-686494be4177.png)

</details>
