### PR TITLE
Add support for `from`, `to` and `method` modifiers

### DIFF
--- a/syntaxes/adblock.tmLanguage.json
+++ b/syntaxes/adblock.tmLanguage.json
@@ -764,6 +764,10 @@
 									"name": "string.unquoted.adblock"
 								},
 								{
+									"match": "~|\\|",
+									"name": "keyword.operator.adblock"
+								},
+								{
 									"match": ".+",
 									"name": "invalid.illegal.method-value"
 								}

--- a/syntaxes/adblock.tmLanguage.json
+++ b/syntaxes/adblock.tmLanguage.json
@@ -578,7 +578,7 @@
 					}
 				},
 				{
-					"match": "(domain|denyallow)(=)([^,]+)",
+					"match": "(domain|denyallow|from|to)(=)([^,]+)",
 					"captures": {
 						"1": {
 							"name": "keyword.other.adblock"
@@ -745,6 +745,29 @@
 						},
 						"4": {
 							"name": "string.unquoted.adblock"
+						}
+					}
+				},
+				{
+					"match": "(method)(=)([^,]+)",
+					"captures": {
+						"1": {
+							"name": "keyword.other.adblock"
+						},
+						"2": {
+							"name": "keyword.operator.adblock"
+						},
+						"3": {
+							"patterns": [
+								{
+									"match": "(?i)(connect|delete|get|head|options|patch|post|put)",
+									"name": "string.unquoted.adblock"
+								},
+								{
+									"match": ".+",
+									"name": "invalid.illegal.method-value"
+								}
+							]
 						}
 					}
 				},


### PR DESCRIPTION
Fix https://github.com/ameshkov/VscodeAdblockSyntax/issues/58

@MasterKia Please try it by clicking [here](https://novalightshow.netlify.app/?grammar-type=url&grammar=https%3A%2F%2Fraw.githubusercontent.com%2Fscripthunter7%2FVscodeAdblockSyntax%2Ffrom-to-method-modifiers%2Fsyntaxes%2Fadblock.tmLanguage.json&sample-type=text&sample=example.com%24from%3Dsomething%2Cto%3Dsomething%2Cmethod%3Dinvalid%2Cmethod%3Dget%2Cmethod%3DGET) (this is a demo environment almost equivalent to Linguist highlighting).
